### PR TITLE
Build cdecl and xlibs on ports targets.

### DIFF
--- a/ports/makefile
+++ b/ports/makefile
@@ -9,15 +9,15 @@
 port:
 	$(MAKE) -C scrt port
 	$(MAKE) -C scsc port
-	$(MAKE)	-C test autotest
+	$(MAKE) -C test autotest
 
 # Install in system directories; use prefix=~ for private copy
 
 install:
 	$(MAKE) -C scrt install
-	$(MAKE) -C scsc install	
-#	$(MAKE) -C cdecl install	
-#	$(MAKE) -C xlib install
+	$(MAKE) -C scsc install
+	$(MAKE) -C cdecl install
+	$(MAKE) -C xlib install
 
 # Clean out working files.
 
@@ -25,6 +25,8 @@ clean:
 	rm -f *.BAK *.CKP SC-TO-C*
 	$(MAKE) -C scrt clean
 	$(MAKE) -C scsc clean
+	$(MAKE) -C cdecl clean
+	$(MAKE) -C xlib clean
 	$(MAKE) -C test clean
 
 # Clean up C source files generated from Scheme source.
@@ -32,6 +34,8 @@ clean:
 clean-sc-to-c:
 	$(MAKE) -C scrt clean-sc-to-c
 	$(MAKE) -C scsc clean-sc-to-c
+	$(MAKE) -C cdecl clean-sc-to-c
+	$(MAKE) -C xlib clean-sc-to-c
 	$(MAKE) -C test clean-sc-to-c
 
 # Delete programs and libraries.
@@ -39,6 +43,8 @@ clean-sc-to-c:
 noprogs:
 	$(MAKE) -C scrt noprogs
 	$(MAKE) -C scsc noprogs
+	$(MAKE) -C cdecl noprogs
+	$(MAKE) -C xlib noprogs
 	$(MAKE) -C test noprogs
 
 # All files which must be constructed are made by the following command:
@@ -46,3 +52,5 @@ noprogs:
 all:
 	$(MAKE) -C scrt all
 	$(MAKE) -C scsc all
+	$(MAKE) -C cdecl all
+	$(MAKE) -C xlib all


### PR DESCRIPTION
This is needed for running ezdraw (ezd) with scheme2c.